### PR TITLE
fix: readme stats not showing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
         <img align="center" alt="Logo-Java" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/java-plain.svg"></a>
     </div><br>
     <a href="https://github.com/Luccatp">
-    <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=Luccatp&layout=compact&langs_count=7&theme=dark"/>
-    <img height="180em" src="https://github-readme-stats.vercel.app/api?username=Luccatp&show_icons=true&theme=dark&include_all_commits=true&count_private=true"/></a>
+    <img height="180em" src="https://felipefreitassilva-github-readme-stats.vercel.app/api/top-langs/?username=Luccatp&layout=compact&langs_count=7&theme=dark"/>
+    <img height="180em" src="https://felipefreitassilva-github-readme-stats.vercel.app/api?username=Luccatp&show_icons=true&theme=dark&include_all_commits=true&count_private=true"/></a>
 </div>
 
 <div>


### PR DESCRIPTION
Altered Readme Stats import to newly forked repository in a new Vercel instance